### PR TITLE
Fix the resizing of text area in contact us form, remove not using CSS selectors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,10 +143,7 @@
           <div>
             <h2>Contact Us</h2>
             <p>
-              Ready to take it to the next level? Let's talk about your project
-              or idea and find out how we can help your business grow. If you
-              are looking for unique digital experiences that are relatable to
-              your users, drop us a line.
+              Ready to take it to the next level? Let's talk about your project or idea and find out how we can help your business grow. If you are looking for unique digital experiences that are relatable to your users, drop us a line.
             </p>
           </div>
           <form

--- a/style.css
+++ b/style.css
@@ -202,7 +202,6 @@ ul {
   gap: 1rem;
   align-items: center;
 }
-/* this style is for test navigation, you can delete it */
 section {
   max-width: 60rem;
 }
@@ -220,11 +219,10 @@ footer {
   gap: 1rem;
   padding: 30px;
 }
-
+/* ---------------- footer ---------------------- */
 footer > div > p {
   color: var(--white-100);
 }
-
 .footer-logo-container {
   max-width: 1110px;
   width: 75%;
@@ -239,8 +237,8 @@ footer > div > p {
   align-items: center;
   gap: 30px;
   flex-wrap: wrap;
-  /* text-align: center; */
 }
+/* ---------------- contact us ---------------------- */
 #contacts {
   display: flex;
   flex-flow: column wrap;
@@ -284,6 +282,10 @@ textarea {
   margin-bottom: 1rem;
   color: var(--white-100);
 }
+.contact-container>form>textarea {
+  resize: none;
+  font-family: "Roboto", sans-serif;
+}
 .contact-container > form > button {
   margin-top: 1rem;
   align-self: flex-end;
@@ -293,16 +295,9 @@ textarea {
   border-radius: 0.5rem;
   cursor: pointer;
 }
-.contact-container > form::placeholder {
-  color: var(--white-100);
-  opacity: 0.5;
-}
 .contact-container > img {
   position: absolute;
   z-index: -10;
-}
-.contact-container > img:nth-child(2) {
-  display: none;
 }
 @media screen and (max-width: 768px) {
   #contacts {
@@ -344,27 +339,16 @@ textarea {
     border-bottom: 1px solid var(--white-100);
     padding-bottom: 10px;
   }
+  .contact-container>form>textarea {
+    resize: none;
+    font-family: "Roboto", sans-serif;
+  }
   .contact-container > form > button {
     align-self: center;
     width: 10rem;
     height: 3rem;
     border: none;
     border-radius: 0.5rem;
-  }
-  .contact-container > form ::placeholder {
-    color: var(--white-100);
-    opacity: 0.5;
-  }
-  .contact-container > img {
-    position: absolute;
-    margin: 0 auto;
-    z-index: -10;
-  }
-  .contact-container > img:first-child {
-    display: none;
-  }
-  .contact-container > img:nth-child(2) {
-    display: flex;
   }
   footer {
     min-height: 20rem;


### PR DESCRIPTION
Closes #64 

- Constrain the resizing of text area in contact us form.
- Remove the CSS selectors which is not used anymore in the html. 